### PR TITLE
Fix String::at bounds check

### DIFF
--- a/include/String.hpp
+++ b/include/String.hpp
@@ -44,12 +44,12 @@ public:
     constexpr const char& operator[](size_type i) const  { return data_[i]; }
 
     char& at(size_type i) {
-        if (i > size_) 
+        if (i >= size_)
             error_trap();
         return data_[i];
     }
     const char& at(size_type i) const {
-        if (i > size_) 
+        if (i >= size_)
             error_trap();
         return data_[i];
     }


### PR DESCRIPTION
## Summary
- fix off-by-one error in `String::at`

## Testing
- `cmake --build .` in build2
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_683f892a08f08326b2a2170cfe8c38a3